### PR TITLE
Update TestRealSense.cpp

### DIFF
--- a/src/Test/TestRealSense.cpp
+++ b/src/Test/TestRealSense.cpp
@@ -106,9 +106,9 @@ int main(int argc, char **args)
 	PrintInfo("\n\n");
 
 	Visualizer depth_vis, color_vis;
-	if (depth_vis.CreateWindow("Depth", 640, 480, 15, 50) == false ||
+	if (depth_vis.CreateVisualizerWindow("Depth", 640, 480, 15, 50) == false ||
 			depth_vis.AddGeometry(depth_image_ptr) == false ||
-			color_vis.CreateWindow("Color", 1920, 1080, 675, 50) == false ||
+			color_vis.CreateVisualizerWindow("Color", 1920, 1080, 675, 50) == false ||
 			color_vis.AddGeometry(color_image_ptr) == false) {
 		return 0;
 	}

--- a/src/Visualization/Visualizer/Visualizer.h
+++ b/src/Visualization/Visualizer/Visualizer.h
@@ -101,7 +101,7 @@ public:
 
     /// Function to add geometry to the scene and create corresponding shaders
     /// 1. After calling this function, the Visualizer owns the geometry object.
-    /// 2. This function MUST be called after CreateWindow().
+    /// 2. This function MUST be called after CreateVisualizerWindow().
     /// 3. This function returns FALSE when the geometry is of an unsupported
     /// type.
     /// 4. If an added geometry is changed, the behavior of Visualizer is


### PR DESCRIPTION
fixing the recent change of the `CreateWindow` to `CreateVisualizerWindow` related to  https://github.com/IntelVCL/Open3D/issues/422 in the TestRealSense.cpp file which leads to an error in the compilation if build tests is enabled otherwise